### PR TITLE
fix: add email to author field for valid-author lint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 		"node": ">=20.15"
 	},
 	"author": {
-		"name": "Aotokitsuruya"
+		"name": "Aotokitsuruya",
+		"email": "contact@aotoki.me"
 	},
 	"license": "MIT",
 	"n8n": {


### PR DESCRIPTION
## Intent

The `@n8n/node-cli` `valid-author` lint rule (introduced in newer versions, e.g. 0.38.4) requires the `package.json` `author` field to include a non-empty email. Without it, CI fails on tooling upgrades such as #109.

This adds the author email to unblock CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)